### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kgeography.json
+++ b/org.kde.kgeography.json
@@ -11,6 +11,9 @@
         "--socket=fallback-x11",
         "--socket=wayland"
     ],
+     "cleanup": [
+        "/share/doc"
+    ],
     "modules": [
         {
             "name": "kgeography",


### PR DESCRIPTION
The installed size reduced from 11.6 MB to 8.7 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.